### PR TITLE
fix: allow dependency injection in factory

### DIFF
--- a/src/nestjs-ftp.module.ts
+++ b/src/nestjs-ftp.module.ts
@@ -9,6 +9,7 @@ export class FtpModule {
   static forRootFtpAsync(options: IFtpConnectionOptions): DynamicModule {
     return {
         module: FtpModule,
+        imports: options.imports || [],
         providers: [
             {
                 provide: CONFIG_CONNECTION_OPTIONS,


### PR DESCRIPTION
In the current state external provider cannot be injected into `useFactory` in module init.
The `imports` option was able to be set in `IFtpConnectionOptions` but wasn't really handled.